### PR TITLE
feat: implement predictive load balancing with virtual RAM reservation

### DIFF
--- a/assets/js/components/Instances/InstanceManager.js
+++ b/assets/js/components/Instances/InstanceManager.js
@@ -166,20 +166,44 @@ function InstanceManager(props = {lab: {}, user: {}, labInstance: {}, isJitsiCal
         setViewAs(option);
     }
 
+    async function pollForLabInstance(labUuid, instancierUuid, type, attempts = 0) {
+        if (attempts > 60) throw new Error("Timeout waiting for lab creation");
+        try {
+            let res;
+            if (type === 'user') res = await Remotelabz.instances.lab.getByLabAndUser(labUuid, instancierUuid);
+            else if (type === 'guest') res = await Remotelabz.instances.lab.getByLabAndGuest(labUuid, instancierUuid);
+            else if (type === 'group') res = await Remotelabz.instances.lab.getByLabAndGroup(labUuid, instancierUuid);
+            
+            if (res && res.data) {
+                return res.data;
+            }
+        } catch (e) {
+            if (e.response && e.response.status !== 404) throw e;
+        }
+        await new Promise(r => setTimeout(r, 2000));
+        return pollForLabInstance(labUuid, instancierUuid, type, attempts + 1);
+    }
+
     async function onJoinLab() {
         setLoadingInstanceState(true);
         try {
             const response = await Remotelabz.instances.lab.create(props.lab.uuid, viewAs.uuid, viewAs.type, false);
-            setLabInstance(response.data);
+            
+            let finalInstance = response.data;
+            if (response.status === 202) {
+                finalInstance = await pollForLabInstance(props.lab.uuid, viewAs.uuid, viewAs.type);
+            }
+
+            setLabInstance(finalInstance);
             setLoadingInstanceState(false);
             if (!isSandbox) {
                 $.ajax({
                     type: "POST",
                     url: `/api/editButton/display`,
-                    data: JSON.stringify({ user: props.user, lab: props.lab, labInstance: response.data }),
+                    data: JSON.stringify({ user: props.user, lab: props.lab, labInstance: finalInstance }),
                     dataType: "json",
-                    success: function (response) {
-                        $("#instanceButtons").html(response.data.html);
+                    success: function (res) {
+                        $("#instanceButtons").html(res.data.html);
                     }
                 });
             }

--- a/assets/js/components/Sandbox/SandboxListItem.js
+++ b/assets/js/components/Sandbox/SandboxListItem.js
@@ -120,9 +120,19 @@ class SandboxListItem extends Component {
                             console.error("Error adding device:", deviceError);
                             throw deviceError; // Re-lancer pour être capturé par le catch principal
                         }
-                            // Création de l'instance avec gestion d'erreur spécifique
                         try {
-                            await Remotelabz.instances.lab.create(lab.uuid, this.props.user.uuid, 'user');
+                            const resCreate = await Remotelabz.instances.lab.create(lab.uuid, this.props.user.uuid, 'user');
+                            if (resCreate.status === 202) {
+                                let attempts = 0;
+                                while(attempts < 30) {
+                                    try {
+                                        const resPoll = await Remotelabz.instances.lab.getByLabAndUser(lab.uuid, this.props.user.uuid);
+                                        if (resPoll && resPoll.data) break;
+                                    } catch(e) { if (e.response && e.response.status !== 404) throw e; }
+                                    await new Promise(r => setTimeout(r, 2000));
+                                    attempts++;
+                                }
+                            }
                         } catch (instanceError) {
                             console.error("Error creating lab instance:", instanceError);
                             throw instanceError;
@@ -179,7 +189,18 @@ class SandboxListItem extends Component {
 
                         Remotelabz.labs.copyBanner(this.props.item.id, lab.id);
 
-                        await Remotelabz.instances.lab.create(lab.uuid, this.props.user.uuid, 'user');
+                        const resCreate = await Remotelabz.instances.lab.create(lab.uuid, this.props.user.uuid, 'user');
+                        if (resCreate.status === 202) {
+                            let attempts = 0;
+                            while(attempts < 30) {
+                                try {
+                                    const resPoll = await Remotelabz.instances.lab.getByLabAndUser(lab.uuid, this.props.user.uuid);
+                                    if (resPoll && resPoll.data) break;
+                                } catch(e) { if (e.response && e.response.status !== 404) throw e; }
+                                await new Promise(r => setTimeout(r, 2000));
+                                attempts++;
+                            }
+                        }
                         //console.log("Rendering lab in modify function after lab create ", lab);
 
                         window.location.href = "/admin/sandbox/" + lab.id;

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -27,3 +27,4 @@ framework:
         routing:
             Remotelabz\Message\Message\InstanceActionMessage: worker
             Remotelabz\Message\Message\InstanceStateMessage: front
+            Remotelabz\Message\Message\LabLaunchRequestMessage: async

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -301,6 +301,7 @@ services:
     App\Controller\InstanceController:
         arguments:
             $remotelabzProxyUseWss: '%app.services.proxy.wss%'
+            $bus: '@Symfony\Component\Messenger\MessageBusInterface'
 
     App\MessageHandler\InstanceStateMessageHandler:
         arguments:

--- a/src/Command/TestHiddenLoadCommand.php
+++ b/src/Command/TestHiddenLoadCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\LabInstance;
+use App\Service\Worker\WorkerManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Repository\LabRepository;
+
+class TestHiddenLoadCommand extends Command
+{
+    protected static $defaultName = 'app:test-hidden-load';
+    private $em;
+    private $wm;
+    private $lr;
+
+    public function __construct(EntityManagerInterface $em, WorkerManager $wm, LabRepository $lr)
+    {
+        $this->em = $em;
+        $this->wm = $wm;
+        $this->lr = $lr;
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $repo = $this->em->getRepository(LabInstance::class);
+        $instances = $repo->findBy(['state' => 'creating']);
+        
+        $output->writeln("Found " . count($instances) . " instances in state 'creating'");
+        
+        foreach ($instances as $inst) {
+            $output->writeln("Instance: " . $inst->getUuid() . " on worker: " . $inst->getWorkerIp());
+            if ($inst->getLab()) {
+                $mem = $this->wm->Memory_Usage($inst->getLab());
+                $output->writeln(" - Memory usage: " . $mem . " MB");
+            }
+        }
+        
+        $lab = $this->lr->find(16);
+        if ($lab) {
+            $output->writeln("Lab 16 memory needed: " . $this->wm->Memory_Usage($lab) . " MB");
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/InstanceController.php
+++ b/src/Controller/InstanceController.php
@@ -74,6 +74,7 @@ class InstanceController extends Controller
     private $serializer;
     protected $remotelabzProxyUseWss;
     private $configworkerRepository;
+    private $bus;
 
     /** @var EntityManagerInterface */
     protected $entityManager;
@@ -93,7 +94,8 @@ class InstanceController extends Controller
         SerializerInterface $serializerInterface,
         bool $remotelabzProxyUseWss,
         ConfigWorkerRepository $configworkerRepository,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $entityManager,
+        \Symfony\Component\Messenger\MessageBusInterface $bus
     ) {
         $this->logger = $logger;
         $this->labInstanceRepository = $labInstanceRepository;
@@ -107,6 +109,7 @@ class InstanceController extends Controller
         $this->remotelabzProxyUseWss = $remotelabzProxyUseWss;
         $this->configworkerRepository = $configworkerRepository;
         $this->entityManager = $entityManager;
+        $this->bus = $bus;
     }
 
     #[Security("is_granted('ROLE_USER')", message: "Access denied.")]
@@ -515,33 +518,69 @@ class InstanceController extends Controller
             $this->logger->debug("[InstanceController:createAction]::Lab instance creation: " . $lab->getName());
             if ($instancierType == "guest") {
                 $this->logger->info("The guest" . $this->getUser()->getMail() . " " . $this->getUser()->getUuid() . " enter in lab " . $lab->getName() . " " . $lab->getUuid());
+                $instance = $instanceManager->create($lab, $instancier);
+                if (!is_null($instance)) {
+                    $this->logger->info("Lab instance " . $instance->getUuid() . " created by guest " . $this->getUser()->getMail() . " " . $this->getUser()->getUuid() . " Wait ack created message");
+                    $this->logger->info("Lab instance " . $instance->getUuid() . " executed on Worker " . $instance->getWorkerIp());
+                } else
+                    $this->logger->info("User " . $username . " has already an instance of the lab " . $lab->getName());
             } else {
                 $this->logger->info($this->getUser()->getFirstname() . " " . $username . " " . $this->getUser()->getUuid() . " enter in lab " . $lab->getName() . " " . $lab->getUuid());
+                // Utilisation du Dispatcher Asynchrone (RabbitMQ)
+                $fromExport = $request->request->all()['fromexport'] ?? 0;
+                $fromExport = filter_var($fromExport, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
+                
+                $this->bus->dispatch(new \Remotelabz\Message\Message\LabLaunchRequestMessage($lab->getUuid(), $instancier->getUuid(), $instancierType, $fromExport));
+                
+                $this->logger->info("[InstanceController:createAction]::Message LabLaunchRequestMessage dispatched for async creation.");
+                
+                return $this->json(['status' => 'pending', 'message' => 'Lab creation queued'], 202);
             }
-
-            $instance = $instanceManager->create($lab, $instancier);
-            if (!is_null($instance)) {
-                switch ($instancierType) {
-                    case "guest":
-                        $this->logger->info("Lab instance " . $instance->getUuid() . " created by guest " . $this->getUser()->getMail() . " " . $this->getUser()->getUuid() . " Wait ack created message");
-                        $this->logger->info("Lab instance " . $instance->getUuid() . " executed on Worker " . $instance->getWorkerIp());
-                        break;
-                    case "user":
-                        $this->logger->info("Lab instance " . $instance->getUuid() . " created by user " . $this->getUser()->getFirstname() . " " . $username . " " . $this->getUser()->getUuid() . " Wait ack created message");
-                        $this->logger->info("Lab instance " . $instance->getUuid() . " executed on Worker " . $instance->getWorkerIp());
-                        break;
-                    case "group":
-                        $this->logger->info("Lab instance " . $instance->getUuid() . " created by group " . $instancier->getName() . " Wait ack created message");
-                        $this->logger->info("Lab instance " . $instance->getUuid() . " executed on Worker " . $instance->getWorkerIp());
-                        break;
-                }
-            } else
-                $this->logger->info("User " . $username . " has already an instance of the lab " . $lab->getName());
         } catch (Exception $e) {
             throw $e;
         }
 
         return $this->json($instance, 200, [], ['api_get_lab_instance']);
+    }
+
+    #[Route(path: '/api/instances/create-batch', name: 'api_create_instance_batch', methods: ['POST'])]
+    #[Security("is_granted('ROLE_USER')", message: "Access denied.")]
+    public function createBatchAction(Request $request, InstanceManager $instanceManager, 
+        GroupRepository $groupRepository, LabRepository $labRepository, \App\Service\Worker\WorkerManager $workerManager, \Symfony\Component\Messenger\MessageBusInterface $bus)
+    {
+        error_log("CREATE BATCH ACTION CALLED!");
+        $labUuid = $request->request->all()['lab'] ?? null;
+        $groupUuid = $request->request->all()['group'] ?? null;
+
+        if (!$labUuid || !$groupUuid) {
+            throw new BadRequestHttpException('Missing lab or group UUID.');
+        }
+
+        $group = $groupRepository->findOneBy(['uuid' => $groupUuid]);
+        $lab = $labRepository->findOneBy(['uuid' => $labUuid]);
+        
+        $this->denyAccessUnlessGranted(LabVoter::SEE, $lab);
+
+        try {
+            $this->logger->info("[InstanceController:createBatchAction]::Collective launch for group " . $group->getName() . " on lab " . $lab->getName());
+            
+            $fromExport = $request->request->all()['fromexport'] ?? 0;
+            $fromExport = filter_var($fromExport, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
+            
+            $dispatchedCount = 0;
+            foreach ($group->getUsers() as $student) {
+                // Utilisation du Dispatcher Asynchrone (RabbitMQ) - Stratégie 2
+                $bus->dispatch(new \Remotelabz\Message\Message\LabLaunchRequestMessage($lab->getUuid(), $student->getUuid(), 'user', $fromExport));
+                $dispatchedCount++;
+            }
+            
+            $this->logger->info("[InstanceController:createBatchAction]::$dispatchedCount messages LabLaunchRequestMessage dispatched for async collective creation.");
+            
+            return $this->json(['status' => 'pending', 'message' => "$dispatchedCount labs queued for creation"], 202);
+
+        } catch (\Exception $e) {
+            throw $e;
+        }
     }
 
 

--- a/src/MessageHandler/LabLaunchRequestMessageHandler.php
+++ b/src/MessageHandler/LabLaunchRequestMessageHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Repository\GroupRepository;
+use App\Repository\InvitationCodeRepository;
+use App\Repository\LabRepository;
+use App\Repository\UserRepository;
+use App\Service\Instance\InstanceManager;
+use App\Service\Worker\WorkerManager;
+use Psr\Log\LoggerInterface;
+use Remotelabz\Message\Message\LabLaunchRequestMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class LabLaunchRequestMessageHandler
+{
+    private $instanceManager;
+    private $userRepository;
+    private $invitationCodeRepository;
+    private $groupRepository;
+    private $labRepository;
+    private $workerManager;
+    private $logger;
+
+    // Cache (TTL 15s) pour éviter de surcharger les workers d'appels HTTP réseau
+    private static $cachedMetrics = null;
+    private static $lastFetch = 0;
+
+    public function __construct(
+        InstanceManager $instanceManager,
+        UserRepository $userRepository,
+        InvitationCodeRepository $invitationCodeRepository,
+        GroupRepository $groupRepository,
+        LabRepository $labRepository,
+        WorkerManager $workerManager,
+        LoggerInterface $logger
+    ) {
+        $this->instanceManager = $instanceManager;
+        $this->userRepository = $userRepository;
+        $this->invitationCodeRepository = $invitationCodeRepository;
+        $this->groupRepository = $groupRepository;
+        $this->labRepository = $labRepository;
+        $this->workerManager = $workerManager;
+        $this->logger = $logger;
+    }
+
+    public function __invoke(LabLaunchRequestMessage $message)
+    {
+        $this->logger->info("[LabLaunchRequestMessageHandler] Traitement de la requête de lancement asynchrone pour le lab " . $message->getLabUuid());
+
+        $lab = $this->labRepository->findOneBy(['uuid' => $message->getLabUuid()]);
+        
+        switch ($message->getInstancierType()) {
+            case 'user':
+                $instancier = $this->userRepository->findOneBy(['uuid' => $message->getInstancierUuid()]);
+                break;
+            case 'guest':
+                $instancier = $this->invitationCodeRepository->findOneBy(['uuid' => $message->getInstancierUuid()]);
+                break;
+            case 'group':
+                $instancier = $this->groupRepository->findOneBy(['uuid' => $message->getInstancierUuid()]);
+                break;
+            default:
+                throw new \Exception("Unknown instancier type.");
+        }
+
+        if (!$lab || !$instancier) {
+            $this->logger->error("[LabLaunchRequestMessageHandler] Lab ou Instancier introuvable.");
+            return;
+        }
+
+        // 1. Rafraîchir les métriques réelles (TTL 15s OU si un Worker vient de tomber)
+        //    Le flag WorkerManager::$cacheInvalidated est mis à true par checkWorkersLightAction()
+        //    dès qu'un Worker ne répond plus, pour éviter qu'il reste dans le cache.
+        if (time() - self::$lastFetch > 15 || self::$cachedMetrics === null || WorkerManager::$cacheInvalidated) {
+            if (WorkerManager::$cacheInvalidated) {
+                $this->logger->info("[LabLaunchRequestMessageHandler] Un Worker est tombé : cache invalidé, rechargement immédiat des métriques.");
+                WorkerManager::$cacheInvalidated = false; // reset du flag
+            } else {
+                $this->logger->info("[LabLaunchRequestMessageHandler] Récupération des vraies métriques via checkWorkersLightAction.");
+            }
+            self::$cachedMetrics = $this->workerManager->checkWorkersLightAction();
+            self::$lastFetch = time();
+        }
+
+        // 2. Sélection du meilleur worker (La charge cachée "creating" est lue en BDD)
+        $memoryNeeded = $this->workerManager->Memory_Usage($lab);
+        $bestWorkerIp = $this->workerManager->getBestWorkerFromMetrics(self::$cachedMetrics, $memoryNeeded);
+
+        if (empty($bestWorkerIp)) {
+            $this->logger->error("[LabLaunchRequestMessageHandler] Aucun worker disponible pour le lab " . $lab->getName());
+            return;
+        }
+
+        $this->logger->info("[LabLaunchRequestMessageHandler] Worker assigné : " . $bestWorkerIp);
+
+        // 3. Création de l'instance et délégation au worker ciblé
+        $this->instanceManager->create($lab, $instancier, $bestWorkerIp);
+    }
+}

--- a/src/Service/Instance/InstanceManager.php
+++ b/src/Service/Instance/InstanceManager.php
@@ -148,7 +148,7 @@ class InstanceManager
      *
      * @return LabInstance
      */
-    public function create(Lab $lab, InstancierInterface $instancier)
+    public function create(Lab $lab, InstancierInterface $instancier, $workerIp = null)
     {
 
         // Test is this user, guest or group has already started an instance of this lab
@@ -171,7 +171,16 @@ class InstanceManager
 
         if (is_null($is_exist_labinstance)) {
 
-                $worker = $this->workerManager->getFreeWorker($lab);
+                // Si un Worker est imposé (ex: admin), on l'utilise directement.
+                // Sinon on passe par getBestWorkerFromMetrics (Hidden Load Penalty)
+                // pour éviter le Thundering Herd.
+                if ($workerIp !== null) {
+                    $worker = $workerIp;
+                } else {
+                    $memory  = $this->workerManager->Memory_Usage($lab);
+                    $usages  = $this->workerManager->checkWorkersLightAction();
+                    $worker  = $this->workerManager->getBestWorkerFromMetrics($usages, $memory);
+                }
 
             if ($worker == null) {
                 $this->logger->error('[InstanceManager:create]::Could not create instance. No worker available');
@@ -221,7 +230,11 @@ class InstanceManager
                     $this->logger->debug("[InstanceManager:create]::Route to ".$network." exists, via ".$worker);
                 else {
                     $this->logger->debug("[InstanceManager:create]::Route to ".$network." doesn't exist, via ".$worker);
-                    IPTools::routeAdd($network,$worker);
+                    try {
+                        IPTools::routeAdd($network,$worker);
+                    } catch (\Exception $e) {
+                        $this->logger->warning("[InstanceManager:create]::Failed to add route, maybe it was created concurrently: " . $e->getMessage());
+                    }
                 }
             }
 

--- a/src/Service/Worker/WorkerManager.php
+++ b/src/Service/Worker/WorkerManager.php
@@ -9,7 +9,10 @@ use Psr\Log\LoggerInterface;
 use App\Repository\ConfigWorkerRepository;
 use App\Entity\ConfigWorker;
 use App\Entity\Device;
+use App\Entity\LabInstance;
 use Doctrine\Persistence\ManagerRegistry;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 
 class WorkerManager
 {
@@ -58,10 +61,19 @@ class WorkerManager
             return $usage;
     }
 
+    /**
+     * Flag statique pour signaler au MessageHandler que le cache doit être invalidé
+     * car un Worker est tombé pendant la fenêtre de cache.
+     */
+    public static bool $cacheInvalidated = false;
+
     public function checkWorkersLightAction()
     {
-        $client = new Client();
-        //$workers = explode(',', $this->workerServer);
+        // Timeout court (3s) pour détecter rapidement un Worker down
+        $client = new Client([
+            'connect_timeout' => 3,
+            'timeout'         => 5,
+        ]);
         $workers = $this->configWorkerRepository->findBy(["available" => true]);
         $usage = [];
         foreach($workers as $worker) {
@@ -72,24 +84,40 @@ class WorkerManager
                 $this->logger->debug('Get '. $url);
                 $content['worker'] = $worker->getIPv4();
                 array_push($usage, $content);
-            } catch (Exception $exception) {
-                $this->logger->error("Light Usage resources error - Web service or Worker ".$worker->getIPv4()." is not available");               
+            } catch (ConnectException | RequestException $exception) {
+                // Le Worker ne répond pas : on l'exclut IMMÉDIATEMENT du tableau
+                // de résultats (il ne sera PAS candidat à ce cycle de placement)
+                // ET on le marque indisponible en BDD pour les requêtes suivantes.
+                $this->logger->error(
+                    "[WorkerManager] Worker ".$worker->getIPv4()." ne répond pas (timeout/connexion refusée). "
+                    ."Exclusion immédiate du cycle de placement et marquage indisponible en BDD."
+                );
                 $worker->setAvailable(0);
                 $entityManager = $this->doctrine->getManager();
                 $entityManager->persist($worker);
                 $entityManager->flush();
-                $this->logger->info("Worker ".$worker->getIPv4()." is disable");
+                $this->logger->info("[WorkerManager] Worker ".$worker->getIPv4()." marqué indisponible (available=0).");
+
+                // Signaler au MessageHandler que son cache est périmé
+                self::$cacheInvalidated = true;
+            } catch (Exception $exception) {
+                // Toute autre erreur inattendue : même traitement défensif
+                $this->logger->error(
+                    "[WorkerManager] Erreur inattendue pour le Worker ".$worker->getIPv4().": ".$exception->getMessage().". "
+                    ."Exclusion du cycle de placement."
+                );
+                self::$cacheInvalidated = true;
             }
         }
-        $this->logger->info('Usage of each worker:',$usage);
-            return $usage;
+        $this->logger->info('Usage of each worker:', $usage);
+        return $usage;
     }
 
     /*
     $item : the device or the lab we want to execute
     return The value of needed memory for all devices
     */
-    private function Memory_Usage($item)
+    public function Memory_Usage($item)
     {
         $memory=0;
         if ($item instanceof Device) {
@@ -111,8 +139,11 @@ class WorkerManager
     */
     public function getFreeWorker($item)
     {
-        $min=0;
-        $result="";
+        // Initialiser à -999 (et non 0) pour que le Worker le moins mauvais
+        // soit toujours sélectionné, même si tous les scores sont négatifs
+        // (i.e. tous les Workers sont au-dessus de leurs seuils max).
+        $min = -999.0;
+        $result = "";
         $memory=$this->Memory_Usage($item);
         $usages = $this->checkWorkersLightAction();
         
@@ -162,13 +193,61 @@ class WorkerManager
         // Pondérer les scores pour obtenir un score final. On peut donner plus de poids à un paramètre en particulier si besoin.
         $finalScore = ($memoryScore * 0.3) + ($diskScore * 0.1) + ($cpuScore * 0.3) + ($lxcfsScore * 0.3);
     
-        // Si le serveur est surchargé dans l'un des domaines, on considère qu'il est inapte.
-        if ($memory >= $maxMemory || $disk >= $maxDisk || $cpu >= $maxCpu || $lxcfs >= $maxlxcfs ) {
-            $this->logger->info("Worker: ".$worker." is overloaded");
+        // Si le serveur est surchargé dans l'un des domaines, on retourne -1.0
+        // pour garantir qu'il ne sera jamais sélectionné tant qu'un Worker sain est disponible.
+        if ($memory >= $maxMemory || $disk >= $maxDisk || $cpu >= $maxCpu || $lxcfs >= $maxlxcfs) {
+            $this->logger->info("Worker: ".$worker." is overloaded - score forcé à -1.0");
+            return -1.0;
         }
-    
+
         // Retourne le score de santé du serveur
         return $finalScore;
     }
     
+    /**
+     * Sélectionne le meilleur worker depuis un tableau de métriques (Réservation Virtuelle).
+     * @param array $usages Tableau de métriques passé par référence.
+     * @param float $memoryNeeded Mémoire nécessaire.
+     */
+    public function getBestWorkerFromMetrics(array $usages, $memoryNeeded)
+    {
+        $min = -999.0;
+        $result = "";
+
+        $labInstanceRepo = $this->doctrine->getRepository(LabInstance::class);
+
+        foreach ($usages as $index => $usage) {
+            // Find creating instances on this worker
+            $creatingInstances = $labInstanceRepo->findBy([
+                'workerIp' => $usage['worker'],
+                'state' => 'creating'
+            ]);
+
+            $hiddenMemoryMB = 0;
+            foreach ($creatingInstances as $creatingInstance) {
+                if ($creatingInstance->getLab()) {
+                    $hiddenMemoryMB += $this->Memory_Usage($creatingInstance->getLab());
+                }
+            }
+
+            // Convert to percentage and add to current memory usage
+            $hiddenMemoryPercentage = 0;
+            if ($usage['memory_total'] > 0) {
+                $hiddenMemoryPercentage = ($hiddenMemoryMB / $usage['memory_total']) * 100;
+            }
+
+            $effectiveMemory = $usage['memory'] + $hiddenMemoryPercentage;
+
+            $val = $this->loadBalancing($effectiveMemory, $usage['disk'], $usage['cpu'], $memoryNeeded, $usage['memory_total'], $usage['worker'], $usage['lxcfs']);
+            
+            $this->logger->info("[WorkerManager:getBestWorkerFromMetrics]::Worker ".$usage['worker']." evaluated. RealMem: ".$usage['memory'].", HiddenMem: ".$hiddenMemoryPercentage.", Score: ".$val);
+
+            if ($val > $min) {
+                $min = $val;
+                $result = $usage['worker'];
+            }
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
- Add getBestWorkerFromMetrics() in WorkerManager with HiddenMem mechanism
- Dispatch lab creation asynchronously via RabbitMQ (LabLaunchRequestMessage)
- Reduce Worker health check timeout to 3s/5s for fast failure detection
- Add cacheInvalidated flag to force immediate cache refresh on Worker failure
- Fix getFreeWorker() init ( = -999.0) to always select a candidate
- Add score -1.0 in loadBalancing() for overloaded Workers
- Add frontend polling for async HTTP 202 response